### PR TITLE
Prevent the internal Script Editor from reloading

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -431,7 +431,7 @@ String ScriptEditor::_get_debug_tooltip(const String &p_text, Node *_se) {
 }
 
 void ScriptEditor::_breaked(bool p_breaked, bool p_can_debug) {
-	if (bool(EDITOR_GET("text_editor/external/use_external_editor"))) {
+	if (external_editor_active) {
 		return;
 	}
 
@@ -2264,7 +2264,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 
 	// Don't open dominant script if using an external editor.
 	bool use_external_editor =
-			EDITOR_GET("text_editor/external/use_external_editor") ||
+			external_editor_active ||
 			(scr.is_valid() && scr->get_language()->overrides_external_editor());
 	use_external_editor = use_external_editor && !(scr.is_valid() && scr->is_built_in()); // Ignore external editor for built-in scripts.
 	const bool open_dominant = EDITOR_GET("text_editor/behavior/files/open_dominant_script_on_scene_change");
@@ -2596,6 +2596,9 @@ void ScriptEditor::apply_scripts() const {
 }
 
 void ScriptEditor::reload_scripts(bool p_refresh_only) {
+	if (external_editor_active) {
+		return;
+	}
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
 		if (!se) {
@@ -2763,6 +2766,7 @@ void ScriptEditor::_editor_settings_changed() {
 
 	members_overview_enabled = EDITOR_GET("text_editor/script_list/show_members_overview");
 	help_overview_enabled = EDITOR_GET("text_editor/help/show_help_index");
+	external_editor_active = EDITOR_GET("text_editor/external/use_external_editor");
 	_update_members_overview_visibility();
 	_update_help_overview_visibility();
 
@@ -3559,7 +3563,7 @@ TypedArray<ScriptEditorBase> ScriptEditor::_get_open_script_editors() const {
 void ScriptEditor::set_scene_root_script(Ref<Script> p_script) {
 	// Don't open dominant script if using an external editor.
 	bool use_external_editor =
-			EDITOR_GET("text_editor/external/use_external_editor") ||
+			external_editor_active ||
 			(p_script.is_valid() && p_script->get_language()->overrides_external_editor());
 	use_external_editor = use_external_editor && !(p_script.is_valid() && p_script->is_built_in()); // Ignore external editor for built-in scripts.
 	const bool open_dominant = EDITOR_GET("text_editor/behavior/files/open_dominant_script_on_scene_change");
@@ -3827,6 +3831,7 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	waiting_update_names = false;
 	pending_auto_reload = false;
 	auto_reload_running_scripts = true;
+	external_editor_active = false;
 	members_overview_enabled = EDITOR_GET("text_editor/script_list/show_members_overview");
 	help_overview_enabled = EDITOR_GET("text_editor/help/show_help_index");
 

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -396,6 +396,7 @@ class ScriptEditor : public PanelContainer {
 	bool open_textfile_after_create = true;
 	bool trim_trailing_whitespace_on_save;
 	bool convert_indent_on_save;
+	bool external_editor_active;
 
 	void _goto_script_line2(int p_line);
 	void _goto_script_line(Ref<RefCounted> p_script, int p_line);


### PR DESCRIPTION
when the external Editor is active in the settings.

This prevents a crash from different race conditions from edititing files in the external editor while the internal editor tries to reload open file tabs.

Some conditions that cause the crash where:
* Syntax highlighting (gdscript_highlighter.cpp, syntax_highlighter.cpp)
* Code analysis (code_edit.cpp)
* ... and more

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
